### PR TITLE
Add viewbox to klingon svg, remove height & width attributes

### DIFF
--- a/custom-flags/tlh.svg
+++ b/custom-flags/tlh.svg
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- Created with Inkscape (http://www.inkscape.org/) -->
-<svg width="512" height="512" version="1.0" xmlns="http://www.w3.org/2000/svg">
+<svg viewbox="0 0 512 512" version="1.0" xmlns="http://www.w3.org/2000/svg">
  <g transform="matrix(.52762 0 0 .52762 .37142 0)">
   <rect x=".78626" width="976.86" height="976.86" fill="#d00"/>
   <ellipse cx="487.27" cy="491.5" rx="303.29" ry="298.64" fill="#fff"/>

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cloudblueconnect/country-flag-mapper",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Country flags as SVG icons mapped to country and locale IDs",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Klingon icon had height & width attributes that messed with its display. Added viewbox attribute instead.